### PR TITLE
fix: support frozen default and use live bindings

### DIFF
--- a/simport.js
+++ b/simport.js
@@ -4,12 +4,85 @@ const {pathToFileURL} = require('url');
 const readjson = require('readjson');
 const tryToCatch = require('try-to-catch');
 
-const {assign} = Object;
+const {apply, construct} = Reflect;
+const {create, defineProperty, getOwnPropertyNames, setPrototypeOf} = Object;
 
 const tryNoExt = async (a) => await import(a);
 const tryJS = async (a) => await import(`${a}.js`);
 const tryMJS = async (a) => await import(`${a}.mjs`);
 const tryCJS = async (a) => await import(`${a}.cjs`);
+
+/** Unwraps the `default` export, if it exists and is an object. */
+const unwrapDefault = (imported) => {
+    const {default: def = null} = imported;
+
+    // The default export is a function:
+    if (typeof def === 'function') {
+        let wrapper;
+        const isCtor = isConstructor(def);
+        if (isCtor) {
+            wrapper = function wrapper(...args) {
+                return new.target !== undefined
+                    ? construct(def, args)
+                    : apply(def, this, args);
+            };
+            wrapper.prototype = undefined;
+        } else {
+            ({wrapper} = {
+                wrapper(...args) {
+                    return apply(def, this, args);
+                },
+            });
+        }
+
+        setPrototypeOf(wrapper, def);
+        return defineBindings(wrapper, imported, isCtor);
+    }
+
+    // The default export is a normal object:
+    if (def !== null && typeof def === 'object') {
+        return defineBindings(create(def), imported);
+    }
+
+    // No default export, or it's a primitive:
+    return imported;
+}
+
+/** Based on: https://github.com/tc39/ecma262/issues/1798#issuecomment-559914634 */
+const isConstructor = (() => {
+    const isConstructorMarker = Symbol();
+    const badArrayLike = {
+        get length() {
+            throw isConstructorMarker;
+        },
+    };
+
+    return (value) => {
+        try {
+            construct(value, badArrayLike);
+        } catch (e) {
+            return e === isConstructorMarker;
+        }
+    };
+})();
+
+/** This is necessary to keep bindings "live" */
+const defineBindings = (target, src, isCtor = false) => {
+    for (const key of getOwnPropertyNames(src)) {
+        if (isCtor && key === 'prototype') {
+            continue;
+        }
+
+        defineProperty(target, key, {
+            configurable: false,
+            enumerable: true,
+            get() {
+                return src[key];
+            },
+        });
+    }
+    return target;
+}
 
 module.exports.createSimport = (url) => {
     url = url.includes('file://') ? url : pathToFileURL(url);
@@ -28,9 +101,7 @@ module.exports.createSimport = (url) => {
         if (/\.(js|mjs|cjs)$/.test(name)) {
             const processed = resolved.href || `file://${resolved}`;
             const imported = await import(processed);
-            const {default: def = {}} = imported;
-            
-            return assign(def, imported);
+            return unwrapDefault(imported);
         }
         
         let imported;
@@ -42,16 +113,13 @@ module.exports.createSimport = (url) => {
         
         if (!imported) {
             [error, imported] = await tryToCatch(tryJS, resolved);
-            imported = imported || await tryToCatch(tryMJS, resolved)[0];
-            imported = imported || await tryToCatch(tryCJS, resolved)[0];
+            imported = imported || await tryToCatch(tryMJS, resolved)[1];
+            imported = imported || await tryToCatch(tryCJS, resolved)[1];
         }
         
         if (!imported)
             throw error;
         
-        const {default: def = {}} = imported;
-        
-        return assign(def, imported);
+        return unwrapDefault(imported);
     };
 };
-

--- a/simport.spec.mjs
+++ b/simport.spec.mjs
@@ -17,7 +17,8 @@ test('simport: default', async (t) => {
     const data = await import('supertape');
     const superData = await simport('supertape');
     
-    t.equal(data.default, superData);
+    t.notEqual(data.default, superData);
+    t.equal(data.default, superData.default);
     t.end();
 });
 
@@ -116,3 +117,51 @@ test('simport: external', async (t) => {
     t.end();
 });
 
+test('simport: `default` export: frozen object', async (t) => {
+    const {__filename} = createCommons(url);
+    const simport = createSimport(__filename);
+
+    const native = await import('./test/fixtures/default-frozen-object.js');
+    const result = await simport('./test/fixtures/default-frozen-object.js');
+    t.equal(typeof result, "object");
+
+    t.notEqual(result, native.default);
+    t.equal(result.default, native.default);
+    t.equal(result.foo, native.foo);
+
+    t.end();
+});
+
+test('simport: `default` export: frozen function', async (t) => {
+    const {__filename} = createCommons(url);
+    const simport = createSimport(__filename);
+
+    const native = await import('./test/fixtures/default-frozen-function.js');
+    const result = await simport('./test/fixtures/default-frozen-function.js');
+    t.equal(typeof result, "function");
+
+    t.notEqual(result, native.default);
+    t.equal(result.default, native.default);
+    t.equal(result.bar, native.bar);
+
+    t.end();
+});
+
+test('simport: `default` export: mutable primitive', async (t) => {
+    const {__filename} = createCommons(url);
+    const simport = createSimport(__filename);
+
+    const native = await import('./test/fixtures/default-mutable-primitive.js');
+    const result = await simport('./test/fixtures/default-mutable-primitive.js');
+
+    t.equal(result, native);
+    t.equal(result.set, native.set);
+    t.equal(result.default, native.default);
+    t.equal(result.default, undefined);
+
+    result.set(123);
+    t.equal(result.default, native.default);
+    t.equal(result.default, 123);
+
+    t.end();
+});

--- a/test/fixtures/default-frozen-function.js
+++ b/test/fixtures/default-frozen-function.js
@@ -1,0 +1,2 @@
+export default Object.freeze((arg) => arg);
+export const bar = "baz";

--- a/test/fixtures/default-frozen-object.js
+++ b/test/fixtures/default-frozen-object.js
@@ -1,0 +1,2 @@
+export default Object.freeze(Object.create(null));
+export const foo = 123;

--- a/test/fixtures/default-mutable-primitive.js
+++ b/test/fixtures/default-mutable-primitive.js
@@ -1,0 +1,8 @@
+let value;
+export {value as default};
+export const set = (newValue) => {
+    if (newValue !== null && (typeof newValue === 'function' || typeof newValue === 'object')) {
+        throw new TypeError("'newValue' must be a primitive");
+    }
+    value = newValue;
+};

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }


### PR DESCRIPTION
This ensures that frozen or primitive `default` exports don’t break `simport`, since it tries to use `Object.apply`, which also creates snapshots of the exported bindings.

---

Using a wrapper with getters ensures that a frozen or primitive `default` continues to work and bindings remain live.